### PR TITLE
pandas was mistakenly imported as np though it's been overriden by correct import of numpy later

### DIFF
--- a/Potato-Price-Artificial-Neural-Network.ipynb
+++ b/Potato-Price-Artificial-Neural-Network.ipynb
@@ -46,7 +46,6 @@
     "from tensorflow import keras\n",
     "\n",
     "import pandas as pd\n",
-    "import pandas as np\n",
     "import numpy as np \n",
     "import matplotlib.pyplot as plt"
    ]


### PR DESCRIPTION
Very first cell of the file:
```python
#Important module and library  to run the program 
import tensorflow as tf
from tensorflow import keras

import pandas as pd
import pandas as np
import numpy as np 
import matplotlib.pyplot as plt
```

Clearly `import pandas as np` was a mistake. It has been removed in this commit.  